### PR TITLE
[FEAT] Config file handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,19 +168,22 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clean-dev-dirs"
-version = "2.3.1"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "chrono",
  "clap",
  "colored",
+ "dirs",
  "hooksmith",
  "humansize",
  "indicatif",
  "inquire",
  "rayon",
+ "serde",
  "serde_json",
  "tempfile",
+ "toml",
  "walkdir",
 ]
 
@@ -294,6 +297,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +385,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -533,6 +568,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +651,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -700,6 +751,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +851,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,7 +945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -908,6 +979,47 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "unicode-ident"
@@ -1311,6 +1423,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "Apache-2.0 OR MIT"
 name = "clean-dev-dirs"
 readme = "README.md"
 repository = "https://github.com/TomPlanche/clean-dev-dirs"
-version = "2.3.1"
+version = "2.4.0"
 
 [lib]
 name = "clean_dev_dirs"
@@ -32,11 +32,14 @@ anyhow = "1.0"
 chrono = "0.4.43"
 clap = { version = "4.5.58", features = ["derive"] }
 colored = "3.1.1"
+dirs = "6.0.0"
 humansize = "2.1.3"
 indicatif = "0.17.11"
 inquire = "0.7"
 rayon = "1.11.0"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.149"
+toml = "0.8"
 walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,11 +3,15 @@
 //! This module defines all command-line arguments, options, and their validation
 //! using the [clap](https://docs.rs/clap/) library. It provides structured access
 //! to user input and handles argument conflicts and defaults.
+//!
+//! Helper methods on [`Cli`] accept a [`FileConfig`] reference so that config-file
+//! values act as defaults that CLI arguments can override (layered config).
 
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 
+use clean_dev_dirs::config::file::{FileConfig, expand_tilde};
 use clean_dev_dirs::config::{ExecutionOptions, FilterOptions, ProjectFilter, ScanOptions};
 
 /// Command-line arguments for filtering projects during cleanup.
@@ -23,15 +27,15 @@ struct FilteringArgs {
     /// - Binary: KiB, MiB, GiB (base 1024)
     /// - Bytes: plain numbers
     /// - Decimal values: 1.5MB, 2.5GiB, etc.
-    #[arg(short = 's', long, default_value = "0")]
-    keep_size: String,
+    #[arg(short = 's', long)]
+    keep_size: Option<String>,
 
     /// Ignore projects that have been compiled in the last \[DAYS\] days
     ///
     /// Projects with build directories modified within this timeframe will be
     /// skipped during cleanup. A value of 0 disables time-based filtering.
-    #[arg(short = 'd', long, default_value = "0")]
-    keep_days: u32,
+    #[arg(short = 'd', long)]
+    keep_days: Option<u32>,
 }
 
 /// Command-line arguments for controlling cleanup execution behavior.
@@ -81,8 +85,8 @@ struct ScanningArgs {
     ///
     /// A value of 0 uses the default number of threads (typically the number of CPU cores).
     /// Higher values can improve scanning performance on systems with fast storage.
-    #[arg(short = 't', long, default_value = "0")]
-    threads: usize,
+    #[arg(short = 't', long)]
+    threads: Option<usize>,
 
     /// Show access errors that occur while scanning
     ///
@@ -110,6 +114,9 @@ struct ScanningArgs {
 ///
 /// This struct defines the complete command-line interface for the clean-dev-dirs tool,
 /// combining all argument groups and providing the main entry point for command parsing.
+///
+/// Helper methods accept a [`FileConfig`] reference so that config-file values act as
+/// defaults when the corresponding CLI argument is not provided.
 #[derive(Parser)]
 #[command(name = "clean-dev-dirs")]
 #[command(about = "Recursively clean Rust, Node.js, Python, and Go development directories")]
@@ -120,15 +127,15 @@ pub struct Cli {
     ///
     /// Specifies the root directory where the tool will recursively search for
     /// development projects. Defaults to the current directory if not specified.
-    #[arg(default_value = ".")]
-    pub dir: PathBuf,
+    #[arg()]
+    dir: Option<PathBuf>,
 
     /// Project type to clean (all, rust, node, python, go)
     ///
     /// Restricts cleaning to specific project types. If not specified, all
     /// supported project types will be considered.
-    #[arg(short = 'p', long, default_value = "all")]
-    project_type: ProjectFilter,
+    #[arg(short = 'p', long)]
+    project_type: Option<ProjectFilter>,
 
     /// Execution options
     #[command(flatten)]
@@ -144,107 +151,153 @@ pub struct Cli {
 }
 
 impl Cli {
-    /// Extract project filter from command-line arguments.
+    /// Resolve the target directory from CLI args, config file, or default.
     ///
-    /// This method returns the project type filter specified by the user.
-    ///
-    /// # Returns
-    ///
-    /// The `ProjectFilter` enum value from the CLI arguments.
+    /// Priority: CLI argument > config file > current directory (`.`).
+    /// Tilde expansion is applied to paths originating from the config file.
     ///
     /// # Examples
     ///
     /// ```no_run
     /// # use clap::Parser;
-    /// # use clean_dev_dirs::cli::Cli;
-    /// # use clean_dev_dirs::config::ProjectFilter;
-    /// let args = Cli::parse_from(&["clean-dev-dirs", "--project-type", "rust"]);
-    /// assert_eq!(args.project_filter(), ProjectFilter::Rust);
+    /// # use clean_dev_dirs::config::FileConfig;
+    /// # use std::path::PathBuf;
+    /// # mod cli { include!("cli.rs"); }
+    /// # use cli::Cli;
+    /// let args = Cli::parse_from(&["clean-dev-dirs", "/custom/path"]);
+    /// assert_eq!(args.directory(&FileConfig::default()), PathBuf::from("/custom/path"));
     /// ```
-    pub fn project_filter(&self) -> ProjectFilter {
-        self.project_type
+    #[must_use]
+    pub fn directory(&self, config: &FileConfig) -> PathBuf {
+        if let Some(ref dir) = self.dir {
+            return dir.clone();
+        }
+
+        if let Some(ref dir) = config.dir {
+            return expand_tilde(dir);
+        }
+
+        PathBuf::from(".")
     }
 
-    /// Extract execution options from command-line arguments.
+    /// Extract project filter from CLI args and config file.
     ///
-    /// This method creates an `ExecutionOptions` struct containing the
-    /// execution-related settings specified by the user.
-    ///
-    /// # Returns
-    ///
-    /// An `ExecutionOptions` struct with the dry-run and interactive flags
-    /// extracted from the command-line arguments.
+    /// Priority: CLI argument > config file > default (`All`).
     ///
     /// # Examples
     ///
     /// ```no_run
     /// # use clap::Parser;
-    /// # use clean_dev_dirs::cli::Cli;
+    /// # use clean_dev_dirs::config::{FileConfig, ProjectFilter};
+    /// # mod cli { include!("cli.rs"); }
+    /// # use cli::Cli;
+    /// let args = Cli::parse_from(&["clean-dev-dirs", "--project-type", "rust"]);
+    /// assert_eq!(args.project_filter(&FileConfig::default()), ProjectFilter::Rust);
+    /// ```
+    #[must_use]
+    pub fn project_filter(&self, config: &FileConfig) -> ProjectFilter {
+        self.project_type
+            .or_else(|| {
+                config
+                    .project_type
+                    .as_ref()
+                    .and_then(|s| ProjectFilter::from_str(s, true).ok())
+            })
+            .unwrap_or_default()
+    }
+
+    /// Extract execution options from CLI args and config file.
+    ///
+    /// For boolean flags, the CLI flag (if set to `true`) takes priority,
+    /// then the config file value, then `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use clap::Parser;
+    /// # use clean_dev_dirs::config::FileConfig;
+    /// # mod cli { include!("cli.rs"); }
+    /// # use cli::Cli;
     /// let args = Cli::parse_from(&["clean-dev-dirs", "--dry-run", "--interactive"]);
-    /// let options = args.execution_options();
+    /// let options = args.execution_options(&FileConfig::default());
     /// assert!(options.dry_run);
     /// assert!(options.interactive);
     /// ```
-    pub fn execution_options(&self) -> ExecutionOptions {
+    #[must_use]
+    pub fn execution_options(&self, config: &FileConfig) -> ExecutionOptions {
         ExecutionOptions {
-            dry_run: self.execution.dry_run,
-            interactive: self.execution.interactive,
-            keep_executables: self.execution.keep_executables,
+            dry_run: self.execution.dry_run || config.execution.dry_run.unwrap_or(false),
+            interactive: self.execution.interactive
+                || config.execution.interactive.unwrap_or(false),
+            keep_executables: self.execution.keep_executables
+                || config.execution.keep_executables.unwrap_or(false),
         }
     }
 
-    /// Extract scanning options from command-line arguments.
+    /// Extract scanning options from CLI args and config file.
     ///
-    /// This method creates a `ScanOptions` struct containing the
-    /// scanning-related settings specified by the user.
-    ///
-    /// # Returns
-    ///
-    /// A `ScanOptions` struct with verbose, threads, and skip options
-    /// extracted from the command-line arguments.
+    /// - **threads**: CLI > config > `0` (default)
+    /// - **verbose**: CLI flag `||` config value `||` `false`
+    /// - **skip**: merged from both sources (config values first, then CLI)
     ///
     /// # Examples
     ///
     /// ```no_run
     /// # use clap::Parser;
-    /// # use clean_dev_dirs::cli::Cli;
+    /// # use clean_dev_dirs::config::FileConfig;
+    /// # mod cli { include!("cli.rs"); }
+    /// # use cli::Cli;
     /// let args = Cli::parse_from(&["clean-dev-dirs", "--verbose", "--threads", "4"]);
-    /// let options = args.scan_options();
+    /// let options = args.scan_options(&FileConfig::default());
     /// assert!(options.verbose);
     /// assert_eq!(options.threads, 4);
     /// ```
-    pub fn scan_options(&self) -> ScanOptions {
+    #[must_use]
+    pub fn scan_options(&self, config: &FileConfig) -> ScanOptions {
+        let mut skip = config.scanning.skip.clone().unwrap_or_default();
+        skip.extend(self.scanning.skip.clone());
+
         ScanOptions {
-            verbose: self.scanning.verbose,
-            threads: self.scanning.threads,
-            skip: self.scanning.skip.clone(),
+            verbose: self.scanning.verbose || config.scanning.verbose.unwrap_or(false),
+            threads: self
+                .scanning
+                .threads
+                .or(config.scanning.threads)
+                .unwrap_or(0),
+            skip,
         }
     }
 
-    /// Extract filtering options from command-line arguments.
+    /// Extract filtering options from CLI args and config file.
     ///
-    /// This method creates a `FilterOptions` struct containing the
-    /// filtering criteria specified by the user.
-    ///
-    /// # Returns
-    ///
-    /// A `FilterOptions` struct with size and time filtering criteria
-    /// extracted from the command-line arguments.
+    /// Priority: CLI argument > config file > hardcoded default.
     ///
     /// # Examples
     ///
     /// ```no_run
     /// # use clap::Parser;
-    /// # use clean_dev_dirs::cli::Cli;
+    /// # use clean_dev_dirs::config::FileConfig;
+    /// # mod cli { include!("cli.rs"); }
+    /// # use cli::Cli;
     /// let args = Cli::parse_from(&["clean-dev-dirs", "--keep-size", "100MB", "--keep-days", "30"]);
-    /// let options = args.filter_options();
+    /// let options = args.filter_options(&FileConfig::default());
     /// assert_eq!(options.keep_size, "100MB");
     /// assert_eq!(options.keep_days, 30);
     /// ```
-    pub fn filter_options(&self) -> FilterOptions {
+    #[must_use]
+    pub fn filter_options(&self, config: &FileConfig) -> FilterOptions {
         FilterOptions {
-            keep_size: self.filtering.keep_size.clone(),
-            keep_days: self.filtering.keep_days,
+            keep_size: self
+                .filtering
+                .keep_size
+                .clone()
+                .or_else(|| config.filtering.keep_size.clone())
+                .unwrap_or_else(|| "0".to_string()),
+            keep_days: self
+                .filtering
+                .keep_days
+                .or(config.filtering.keep_days)
+                .unwrap_or(0),
         }
     }
 }
@@ -253,57 +306,67 @@ impl Cli {
 mod tests {
     use super::*;
     use clap::Parser;
+    use clean_dev_dirs::config::file::{
+        FileConfig, FileExecutionConfig, FileFilterConfig, FileScanConfig,
+    };
+
+    // ── Existing tests (updated for FileConfig parameter) ──────────────
 
     #[test]
     fn test_default_values() {
         let args = Cli::parse_from(["clean-dev-dirs"]);
+        let config = FileConfig::default();
 
-        assert_eq!(args.dir, PathBuf::from("."));
-        assert_eq!(args.project_filter(), ProjectFilter::All);
+        assert_eq!(args.directory(&config), PathBuf::from("."));
+        assert_eq!(args.project_filter(&config), ProjectFilter::All);
 
-        let exec_opts = args.execution_options();
+        let exec_opts = args.execution_options(&config);
         assert!(!exec_opts.dry_run);
         assert!(!exec_opts.interactive);
         assert!(!exec_opts.keep_executables);
 
-        let scan_opts = args.scan_options();
+        let scan_opts = args.scan_options(&config);
         assert!(!scan_opts.verbose);
         assert_eq!(scan_opts.threads, 0);
         assert!(scan_opts.skip.is_empty());
 
-        let filter_opts = args.filter_options();
+        let filter_opts = args.filter_options(&config);
         assert_eq!(filter_opts.keep_size, "0");
         assert_eq!(filter_opts.keep_days, 0);
     }
 
     #[test]
     fn test_project_filters() {
+        let config = FileConfig::default();
+
         let rust_args = Cli::parse_from(["clean-dev-dirs", "--project-type", "rust"]);
-        assert_eq!(rust_args.project_filter(), ProjectFilter::Rust);
+        assert_eq!(rust_args.project_filter(&config), ProjectFilter::Rust);
 
         let node_args = Cli::parse_from(["clean-dev-dirs", "--project-type", "node"]);
-        assert_eq!(node_args.project_filter(), ProjectFilter::Node);
+        assert_eq!(node_args.project_filter(&config), ProjectFilter::Node);
 
         let python_args = Cli::parse_from(["clean-dev-dirs", "--project-type", "python"]);
-        assert_eq!(python_args.project_filter(), ProjectFilter::Python);
+        assert_eq!(python_args.project_filter(&config), ProjectFilter::Python);
 
         let go_args = Cli::parse_from(["clean-dev-dirs", "--project-type", "go"]);
-        assert_eq!(go_args.project_filter(), ProjectFilter::Go);
+        assert_eq!(go_args.project_filter(&config), ProjectFilter::Go);
 
         let all_args = Cli::parse_from(["clean-dev-dirs"]);
-        assert_eq!(all_args.project_filter(), ProjectFilter::All);
+        assert_eq!(all_args.project_filter(&config), ProjectFilter::All);
     }
 
     #[test]
     fn test_project_filter_short_flag() {
+        let config = FileConfig::default();
         let rust_args = Cli::parse_from(["clean-dev-dirs", "-p", "rust"]);
-        assert_eq!(rust_args.project_filter(), ProjectFilter::Rust);
+        assert_eq!(rust_args.project_filter(&config), ProjectFilter::Rust);
     }
 
     #[test]
     fn test_execution_options() {
+        let config = FileConfig::default();
         let args = Cli::parse_from(["clean-dev-dirs", "--dry-run", "--interactive", "--yes"]);
-        let exec_opts = args.execution_options();
+        let exec_opts = args.execution_options(&config);
 
         assert!(exec_opts.dry_run);
         assert!(exec_opts.interactive);
@@ -312,17 +375,20 @@ mod tests {
 
     #[test]
     fn test_keep_executables_flag() {
+        let config = FileConfig::default();
+
         let args = Cli::parse_from(["clean-dev-dirs", "--keep-executables"]);
-        let exec_opts = args.execution_options();
+        let exec_opts = args.execution_options(&config);
         assert!(exec_opts.keep_executables);
 
         let args_short = Cli::parse_from(["clean-dev-dirs", "-k"]);
-        let exec_opts_short = args_short.execution_options();
+        let exec_opts_short = args_short.execution_options(&config);
         assert!(exec_opts_short.keep_executables);
     }
 
     #[test]
     fn test_scanning_options() {
+        let config = FileConfig::default();
         let args = Cli::parse_from([
             "clean-dev-dirs",
             "--verbose",
@@ -333,7 +399,7 @@ mod tests {
             "--skip",
             ".git",
         ]);
-        let scan_opts = args.scan_options();
+        let scan_opts = args.scan_options(&config);
 
         assert!(scan_opts.verbose);
         assert_eq!(scan_opts.threads, 8);
@@ -344,6 +410,7 @@ mod tests {
 
     #[test]
     fn test_filtering_options() {
+        let config = FileConfig::default();
         let args = Cli::parse_from([
             "clean-dev-dirs",
             "--keep-size",
@@ -351,7 +418,7 @@ mod tests {
             "--keep-days",
             "30",
         ]);
-        let filter_opts = args.filter_options();
+        let filter_opts = args.filter_options(&config);
 
         assert_eq!(filter_opts.keep_size, "100MB");
         assert_eq!(filter_opts.keep_days, 30);
@@ -359,12 +426,14 @@ mod tests {
 
     #[test]
     fn test_custom_directory() {
+        let config = FileConfig::default();
         let args = Cli::parse_from(["clean-dev-dirs", "/custom/path"]);
-        assert_eq!(args.dir, PathBuf::from("/custom/path"));
+        assert_eq!(args.directory(&config), PathBuf::from("/custom/path"));
     }
 
     #[test]
     fn test_short_flags() {
+        let config = FileConfig::default();
         let args = Cli::parse_from([
             "clean-dev-dirs",
             "-s",
@@ -378,20 +447,21 @@ mod tests {
             "-y",
         ]);
 
-        let filter_opts = args.filter_options();
+        let filter_opts = args.filter_options(&config);
         assert_eq!(filter_opts.keep_size, "50MB");
         assert_eq!(filter_opts.keep_days, 7);
 
-        let scan_opts = args.scan_options();
+        let scan_opts = args.scan_options(&config);
         assert_eq!(scan_opts.threads, 2);
         assert!(scan_opts.verbose);
 
-        let exec_opts = args.execution_options();
+        let exec_opts = args.execution_options(&config);
         assert!(exec_opts.interactive);
     }
 
     #[test]
     fn test_multiple_skip_directories() {
+        let config = FileConfig::default();
         let args = Cli::parse_from([
             "clean-dev-dirs",
             "--skip",
@@ -404,7 +474,7 @@ mod tests {
             "__pycache__",
         ]);
 
-        let scan_opts = args.scan_options();
+        let scan_opts = args.scan_options(&config);
         assert_eq!(scan_opts.skip.len(), 4);
 
         let expected_dirs = vec![
@@ -421,6 +491,7 @@ mod tests {
 
     #[test]
     fn test_complex_size_formats() {
+        let config = FileConfig::default();
         let test_cases = vec![
             ("100KB", "100KB"),
             ("1.5MB", "1.5MB"),
@@ -430,13 +501,14 @@ mod tests {
 
         for (input, expected) in test_cases {
             let args = Cli::parse_from(["clean-dev-dirs", "--keep-size", input]);
-            let filter_opts = args.filter_options();
+            let filter_opts = args.filter_options(&config);
             assert_eq!(filter_opts.keep_size, expected);
         }
     }
 
     #[test]
     fn test_zero_values() {
+        let config = FileConfig::default();
         let args = Cli::parse_from([
             "clean-dev-dirs",
             "--keep-size",
@@ -447,11 +519,171 @@ mod tests {
             "0",
         ]);
 
-        let filter_opts = args.filter_options();
+        let filter_opts = args.filter_options(&config);
         assert_eq!(filter_opts.keep_size, "0");
         assert_eq!(filter_opts.keep_days, 0);
 
-        let scan_opts = args.scan_options();
+        let scan_opts = args.scan_options(&config);
         assert_eq!(scan_opts.threads, 0);
+    }
+
+    // ── Config merging tests ───────────────────────────────────────────
+
+    #[test]
+    fn test_config_values_used_when_cli_absent() {
+        let args = Cli::parse_from(["clean-dev-dirs"]);
+        let config = FileConfig {
+            project_type: Some("rust".to_string()),
+            dir: Some(PathBuf::from("/config/dir")),
+            filtering: FileFilterConfig {
+                keep_size: Some("50MB".to_string()),
+                keep_days: Some(7),
+            },
+            scanning: FileScanConfig {
+                threads: Some(4),
+                verbose: Some(true),
+                skip: Some(vec![PathBuf::from(".cargo")]),
+                ignore: Some(vec![PathBuf::from(".git")]),
+            },
+            execution: FileExecutionConfig {
+                keep_executables: Some(true),
+                interactive: Some(true),
+                dry_run: Some(true),
+            },
+        };
+
+        assert_eq!(args.directory(&config), PathBuf::from("/config/dir"));
+        assert_eq!(args.project_filter(&config), ProjectFilter::Rust);
+
+        let filter_opts = args.filter_options(&config);
+        assert_eq!(filter_opts.keep_size, "50MB");
+        assert_eq!(filter_opts.keep_days, 7);
+
+        let scan_opts = args.scan_options(&config);
+        assert_eq!(scan_opts.threads, 4);
+        assert!(scan_opts.verbose);
+        assert_eq!(scan_opts.skip, vec![PathBuf::from(".cargo")]);
+
+        let exec_opts = args.execution_options(&config);
+        assert!(exec_opts.keep_executables);
+        assert!(exec_opts.interactive);
+        assert!(exec_opts.dry_run);
+    }
+
+    #[test]
+    fn test_cli_overrides_config_values() {
+        let args = Cli::parse_from([
+            "clean-dev-dirs",
+            "/cli/dir",
+            "--project-type",
+            "node",
+            "--keep-size",
+            "100MB",
+            "--keep-days",
+            "30",
+            "--threads",
+            "8",
+        ]);
+        let config = FileConfig {
+            project_type: Some("rust".to_string()),
+            dir: Some(PathBuf::from("/config/dir")),
+            filtering: FileFilterConfig {
+                keep_size: Some("50MB".to_string()),
+                keep_days: Some(7),
+            },
+            scanning: FileScanConfig {
+                threads: Some(4),
+                ..FileScanConfig::default()
+            },
+            ..FileConfig::default()
+        };
+
+        assert_eq!(args.directory(&config), PathBuf::from("/cli/dir"));
+        assert_eq!(args.project_filter(&config), ProjectFilter::Node);
+
+        let filter_opts = args.filter_options(&config);
+        assert_eq!(filter_opts.keep_size, "100MB");
+        assert_eq!(filter_opts.keep_days, 30);
+
+        let scan_opts = args.scan_options(&config);
+        assert_eq!(scan_opts.threads, 8);
+    }
+
+    #[test]
+    fn test_skip_dirs_merged_from_both_sources() {
+        let args = Cli::parse_from(["clean-dev-dirs", "--skip", "node_modules"]);
+        let config = FileConfig {
+            scanning: FileScanConfig {
+                skip: Some(vec![PathBuf::from(".cargo"), PathBuf::from("vendor")]),
+                ..FileScanConfig::default()
+            },
+            ..FileConfig::default()
+        };
+
+        let scan_opts = args.scan_options(&config);
+        assert_eq!(scan_opts.skip.len(), 3);
+        assert!(scan_opts.skip.contains(&PathBuf::from(".cargo")));
+        assert!(scan_opts.skip.contains(&PathBuf::from("vendor")));
+        assert!(scan_opts.skip.contains(&PathBuf::from("node_modules")));
+    }
+
+    #[test]
+    fn test_bool_flags_override_config_false() {
+        let args = Cli::parse_from(["clean-dev-dirs", "--dry-run"]);
+        let config = FileConfig {
+            execution: FileExecutionConfig {
+                dry_run: Some(false),
+                interactive: Some(true),
+                keep_executables: Some(false),
+            },
+            ..FileConfig::default()
+        };
+
+        let exec_opts = args.execution_options(&config);
+        assert!(exec_opts.dry_run);
+        assert!(exec_opts.interactive);
+        assert!(!exec_opts.keep_executables);
+    }
+
+    #[test]
+    fn test_config_dir_with_tilde_expansion() {
+        let args = Cli::parse_from(["clean-dev-dirs"]);
+        let config = FileConfig {
+            dir: Some(PathBuf::from("~/Projects")),
+            ..FileConfig::default()
+        };
+
+        let dir = args.directory(&config);
+        if let Some(home) = dirs::home_dir() {
+            assert_eq!(dir, home.join("Projects"));
+        }
+    }
+
+    #[test]
+    fn test_config_project_type_case_insensitive() {
+        let args = Cli::parse_from(["clean-dev-dirs"]);
+
+        let config_upper = FileConfig {
+            project_type: Some("Rust".to_string()),
+            ..FileConfig::default()
+        };
+        assert_eq!(args.project_filter(&config_upper), ProjectFilter::Rust);
+
+        let config_mixed = FileConfig {
+            project_type: Some("NODE".to_string()),
+            ..FileConfig::default()
+        };
+        assert_eq!(args.project_filter(&config_mixed), ProjectFilter::Node);
+    }
+
+    #[test]
+    fn test_invalid_config_project_type_falls_back_to_default() {
+        let args = Cli::parse_from(["clean-dev-dirs"]);
+        let config = FileConfig {
+            project_type: Some("invalid_type".to_string()),
+            ..FileConfig::default()
+        };
+
+        assert_eq!(args.project_filter(&config), ProjectFilter::All);
     }
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -1,0 +1,315 @@
+//! Configuration file support for persistent settings.
+//!
+//! This module provides support for loading configuration from a TOML file
+//! located at `~/.config/clean-dev-dirs/config.toml` (or the platform-specific
+//! equivalent). Configuration file values serve as defaults that can be
+//! overridden by CLI arguments.
+//!
+//! # Layering
+//!
+//! The precedence order is: **CLI argument > config file > hardcoded default**.
+//!
+//! # Example config
+//!
+//! ```toml
+//! project_type = "rust"
+//! dir = "~/Projects"
+//!
+//! [filtering]
+//! keep_size = "50MB"
+//! keep_days = 7
+//!
+//! [scanning]
+//! threads = 4
+//! verbose = true
+//! skip = [".cargo", "vendor"]
+//! ignore = [".git"]
+//!
+//! [execution]
+//! keep_executables = true
+//! interactive = false
+//! dry_run = false
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// Top-level configuration file structure.
+///
+/// All fields are `Option<T>` so we can detect which values are present in the
+/// config file and apply layered configuration (CLI > config file > defaults).
+#[derive(Deserialize, Default, Debug)]
+pub struct FileConfig {
+    /// Default project type filter (e.g., `"rust"`, `"node"`, `"all"`)
+    pub project_type: Option<String>,
+
+    /// Default directory to scan
+    pub dir: Option<PathBuf>,
+
+    /// Filtering options
+    #[serde(default)]
+    pub filtering: FileFilterConfig,
+
+    /// Scanning options
+    #[serde(default)]
+    pub scanning: FileScanConfig,
+
+    /// Execution options
+    #[serde(default)]
+    pub execution: FileExecutionConfig,
+}
+
+/// Filtering options from the configuration file.
+#[derive(Deserialize, Default, Debug)]
+pub struct FileFilterConfig {
+    /// Minimum size threshold (e.g., `"50MB"`)
+    pub keep_size: Option<String>,
+
+    /// Minimum age in days
+    pub keep_days: Option<u32>,
+}
+
+/// Scanning options from the configuration file.
+#[derive(Deserialize, Default, Debug)]
+pub struct FileScanConfig {
+    /// Number of threads for scanning
+    pub threads: Option<usize>,
+
+    /// Whether to show verbose output
+    pub verbose: Option<bool>,
+
+    /// Directories to skip during scanning
+    pub skip: Option<Vec<PathBuf>>,
+
+    /// Directories to ignore during scanning
+    pub ignore: Option<Vec<PathBuf>>,
+}
+
+/// Execution options from the configuration file.
+#[derive(Deserialize, Default, Debug)]
+pub struct FileExecutionConfig {
+    /// Whether to preserve compiled executables
+    pub keep_executables: Option<bool>,
+
+    /// Whether to use interactive selection
+    pub interactive: Option<bool>,
+
+    /// Whether to run in dry-run mode
+    pub dry_run: Option<bool>,
+}
+
+/// Expand a leading `~` in a path to the user's home directory.
+///
+/// Paths that don't start with `~` are returned unchanged.
+///
+/// # Examples
+///
+/// ```
+/// # use std::path::PathBuf;
+/// # use clean_dev_dirs::config::file::expand_tilde;
+/// let absolute = PathBuf::from("/absolute/path");
+/// assert_eq!(expand_tilde(&absolute), PathBuf::from("/absolute/path"));
+/// ```
+#[must_use]
+pub fn expand_tilde(path: &Path) -> PathBuf {
+    if let Ok(rest) = path.strip_prefix("~")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(rest);
+    }
+    path.to_path_buf()
+}
+
+impl FileConfig {
+    /// Returns the path where the configuration file is expected.
+    ///
+    /// The configuration file is located at `<config_dir>/clean-dev-dirs/config.toml`,
+    /// where `<config_dir>` is the platform-specific configuration directory
+    /// (e.g., `~/.config` on Linux/macOS, `%APPDATA%` on Windows).
+    ///
+    /// # Returns
+    ///
+    /// `Some(PathBuf)` with the config file path, or `None` if the config
+    /// directory cannot be determined.
+    #[must_use]
+    pub fn config_path() -> Option<PathBuf> {
+        dirs::config_dir().map(|p| p.join("clean-dev-dirs").join("config.toml"))
+    }
+
+    /// Load configuration from the default config file location.
+    ///
+    /// If the config file doesn't exist, returns a default (empty) configuration.
+    /// If the file exists but is malformed, returns an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The config file exists but cannot be read
+    /// - The config file exists but contains invalid TOML or unexpected fields
+    pub fn load() -> anyhow::Result<Self> {
+        let Some(path) = Self::config_path() else {
+            return Ok(Self::default());
+        };
+
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+
+        let content = std::fs::read_to_string(&path).map_err(|e| {
+            anyhow::anyhow!("Failed to read config file at {}: {e}", path.display())
+        })?;
+
+        let config: Self = toml::from_str(&content).map_err(|e| {
+            anyhow::anyhow!("Failed to parse config file at {}: {e}", path.display())
+        })?;
+
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_file_config() {
+        let config = FileConfig::default();
+
+        assert!(config.project_type.is_none());
+        assert!(config.dir.is_none());
+        assert!(config.filtering.keep_size.is_none());
+        assert!(config.filtering.keep_days.is_none());
+        assert!(config.scanning.threads.is_none());
+        assert!(config.scanning.verbose.is_none());
+        assert!(config.scanning.skip.is_none());
+        assert!(config.scanning.ignore.is_none());
+        assert!(config.execution.keep_executables.is_none());
+        assert!(config.execution.interactive.is_none());
+        assert!(config.execution.dry_run.is_none());
+    }
+
+    #[test]
+    fn test_parse_full_config() {
+        let toml_content = r#"
+project_type = "rust"
+dir = "~/Projects"
+
+[filtering]
+keep_size = "50MB"
+keep_days = 7
+
+[scanning]
+threads = 4
+verbose = true
+skip = [".cargo", "vendor"]
+ignore = [".git"]
+
+[execution]
+keep_executables = true
+interactive = false
+dry_run = false
+"#;
+
+        let config: FileConfig = toml::from_str(toml_content).unwrap();
+
+        assert_eq!(config.project_type, Some("rust".to_string()));
+        assert_eq!(config.dir, Some(PathBuf::from("~/Projects")));
+        assert_eq!(config.filtering.keep_size, Some("50MB".to_string()));
+        assert_eq!(config.filtering.keep_days, Some(7));
+        assert_eq!(config.scanning.threads, Some(4));
+        assert_eq!(config.scanning.verbose, Some(true));
+        assert_eq!(
+            config.scanning.skip,
+            Some(vec![PathBuf::from(".cargo"), PathBuf::from("vendor")])
+        );
+        assert_eq!(config.scanning.ignore, Some(vec![PathBuf::from(".git")]));
+        assert_eq!(config.execution.keep_executables, Some(true));
+        assert_eq!(config.execution.interactive, Some(false));
+        assert_eq!(config.execution.dry_run, Some(false));
+    }
+
+    #[test]
+    fn test_parse_partial_config() {
+        let toml_content = r#"
+[filtering]
+keep_size = "100MB"
+"#;
+
+        let config: FileConfig = toml::from_str(toml_content).unwrap();
+
+        assert!(config.project_type.is_none());
+        assert!(config.dir.is_none());
+        assert_eq!(config.filtering.keep_size, Some("100MB".to_string()));
+        assert!(config.filtering.keep_days.is_none());
+        assert!(config.scanning.threads.is_none());
+    }
+
+    #[test]
+    fn test_parse_empty_config() {
+        let toml_content = "";
+        let config: FileConfig = toml::from_str(toml_content).unwrap();
+
+        assert!(config.project_type.is_none());
+        assert!(config.dir.is_none());
+    }
+
+    #[test]
+    fn test_malformed_config_errors() {
+        let toml_content = r#"
+[filtering]
+keep_days = "not_a_number"
+"#;
+        let result = toml::from_str::<FileConfig>(toml_content);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_config_path_returns_expected_suffix() {
+        let path = FileConfig::config_path();
+        if let Some(p) = path {
+            assert!(p.ends_with("clean-dev-dirs/config.toml"));
+        }
+    }
+
+    #[test]
+    fn test_load_returns_defaults_when_no_file() {
+        let config = FileConfig::load().unwrap();
+        assert!(config.project_type.is_none());
+        assert!(config.dir.is_none());
+    }
+
+    #[test]
+    fn test_expand_tilde_with_home() {
+        let path = PathBuf::from("~/Projects");
+        let expanded = expand_tilde(&path);
+
+        if let Some(home) = dirs::home_dir() {
+            assert_eq!(expanded, home.join("Projects"));
+        }
+    }
+
+    #[test]
+    fn test_expand_tilde_absolute_path_unchanged() {
+        let path = PathBuf::from("/absolute/path");
+        let expanded = expand_tilde(&path);
+        assert_eq!(expanded, PathBuf::from("/absolute/path"));
+    }
+
+    #[test]
+    fn test_expand_tilde_relative_path_unchanged() {
+        let path = PathBuf::from("relative/path");
+        let expanded = expand_tilde(&path);
+        assert_eq!(expanded, PathBuf::from("relative/path"));
+    }
+
+    #[test]
+    fn test_expand_tilde_bare() {
+        let path = PathBuf::from("~");
+        let expanded = expand_tilde(&path);
+
+        if let Some(home) = dirs::home_dir() {
+            assert_eq!(expanded, home);
+        }
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,12 +1,14 @@
 //! Configuration types and options for the application.
 //!
 //! This module contains all configuration structures used throughout the application,
-//! including filtering, scanning, and execution options.
+//! including filtering, scanning, execution options, and persistent file-based configuration.
 
 pub mod execution;
+pub mod file;
 pub mod filter;
 pub mod scan;
 
 pub use execution::ExecutionOptions;
+pub use file::FileConfig;
 pub use filter::{FilterOptions, ProjectFilter};
 pub use scan::ScanOptions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub mod utils;
 
 // Re-export commonly used types for convenience
 pub use cleaner::Cleaner;
-pub use config::{ExecutionOptions, FilterOptions, ProjectFilter, ScanOptions};
+pub use config::{ExecutionOptions, FileConfig, FilterOptions, ProjectFilter, ScanOptions};
 pub use filtering::filter_projects;
 pub use project::{BuildArtifacts, Project, ProjectType, Projects};
 pub use scanner::Scanner;


### PR DESCRIPTION
Add persistent config file support at `~/.config/clean-dev-dirs/config.toml` (cross-platform via [`dirs`](https://crates.io/crates/dirs) crate)

CLI arguments override config values; boolean flags are OR'd; list fields (skip, ignore) are merged from both sources

Config file is silently ignored when absent; malformed files produce a clear error with graceful fallback to defaults