### PR TITLE
[FEAT] Add `--name` for filtering with both glob (default) and regex (`regex:<regex>`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,18 +177,20 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clean-dev-dirs"
-version = "2.6.3"
+version = "2.7.0"
 dependencies = [
  "anyhow",
  "chrono",
  "clap",
  "colored",
  "dirs",
+ "glob",
  "hooksmith",
  "humansize",
  "indicatif",
  "inquire",
  "rayon",
+ "regex",
  "serde",
  "serde_json",
  "tempfile",
@@ -411,6 +422,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -792,6 +809,35 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "Apache-2.0 OR MIT"
 name = "clean-dev-dirs"
 readme = "README.md"
 repository = "https://github.com/clean-dev-dirs/clean-dev-dirs"
-version = "2.6.3"
+version = "2.7.0"
 
 [lib]
 name = "clean_dev_dirs"
@@ -30,6 +30,8 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0"
 chrono = "0.4.44"
+glob = "0.3"
+regex = "1"
 clap = { version = "4.5.60", features = ["derive"] }
 colored = "3.1.1"
 dirs = "6.0.0"

--- a/README.md
+++ b/README.md
@@ -177,6 +177,22 @@ clean-dev-dirs --keep-days 30
 clean-dev-dirs --keep-size 50MB --keep-days 7
 ```
 
+### Name Filtering
+
+```bash
+# Only clean projects whose name matches a glob pattern
+clean-dev-dirs --name "my-app*"
+
+# Glob with single-character wildcard
+clean-dev-dirs --name "app-?"
+
+# Use a regular expression (prefix with regex:)
+clean-dev-dirs --name "regex:^client-.*"
+
+# Combine with other filters
+clean-dev-dirs --name "regex:^client-" --keep-size 50MB --dry-run
+```
+
 ### Sorting
 
 ```bash
@@ -377,6 +393,7 @@ keep_size = "50MB"
 keep_days = 7
 sort = "size"       # "size", "age", "name", or "type"
 reverse = false
+# name_pattern = "my-*"   # glob or "regex:^prefix-.*"
 
 [scanning]
 threads = 4
@@ -473,7 +490,12 @@ clean-dev-dirs ~/Projects --permanent --yes
 clean-dev-dirs ~/Projects ~/work/client ~/personal/code --sort size --dry-run
 ```
 
-**12. Set up a config file for your usual workflow:**
+**12. Clean only projects whose name starts with `client-`:**
+```bash
+clean-dev-dirs ~/Projects --name "regex:^client-" --dry-run
+```
+
+**13. Set up a config file for your usual workflow:**
 ```bash
 # Generate a commented-out template at the right platform path
 clean-dev-dirs config init
@@ -514,6 +536,7 @@ clean-dev-dirs config <COMMAND>
 |--------|-------|-------------|
 | `--keep-size` | `-s` | Ignore projects with build dir smaller than specified size |
 | `--keep-days` | `-d` | Ignore projects modified in the last N days |
+| `--name` | | Filter by project name using a glob or `regex:` pattern |
 
 ### Sorting Options
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -23,6 +23,7 @@
 //! keep_days = 7
 //! sort = "size"
 //! reverse = false
+//! # name_pattern = "my-*"
 //!
 //! [scanning]
 //! threads = 4
@@ -84,6 +85,9 @@ pub struct FileFilterConfig {
 
     /// Whether to reverse the sort order
     pub reverse: Option<bool>,
+
+    /// Optional name pattern (glob or `regex:…` prefix) to filter projects by name
+    pub name_pattern: Option<String>,
 }
 
 /// Scanning options from the configuration file.
@@ -206,6 +210,7 @@ mod tests {
         assert!(config.filtering.keep_days.is_none());
         assert!(config.filtering.sort.is_none());
         assert!(config.filtering.reverse.is_none());
+        assert!(config.filtering.name_pattern.is_none());
         assert!(config.scanning.threads.is_none());
         assert!(config.scanning.verbose.is_none());
         assert!(config.scanning.skip.is_none());
@@ -227,6 +232,7 @@ keep_size = "50MB"
 keep_days = 7
 sort = "size"
 reverse = true
+name_pattern = "my-*"
 
 [scanning]
 threads = 4
@@ -249,6 +255,7 @@ use_trash = true
         assert_eq!(config.filtering.keep_days, Some(7));
         assert_eq!(config.filtering.sort, Some("size".to_string()));
         assert_eq!(config.filtering.reverse, Some(true));
+        assert_eq!(config.filtering.name_pattern, Some("my-*".to_string()));
         assert_eq!(config.scanning.threads, Some(4));
         assert_eq!(config.scanning.verbose, Some(true));
         assert_eq!(

--- a/src/config/filter.rs
+++ b/src/config/filter.rs
@@ -78,6 +78,9 @@ pub struct FilterOptions {
 
     /// Minimum age in days for projects to be considered
     pub keep_days: u32,
+
+    /// Optional name pattern (glob or `regex:…` prefix) to filter projects by name
+    pub name_pattern: Option<String>,
 }
 
 /// Enumeration of supported sorting criteria for project output.
@@ -177,10 +180,12 @@ mod tests {
         let filter_opts = FilterOptions {
             keep_size: "100MB".to_string(),
             keep_days: 30,
+            name_pattern: None,
         };
 
         assert_eq!(filter_opts.keep_size, "100MB");
         assert_eq!(filter_opts.keep_days, 30);
+        assert!(filter_opts.name_pattern.is_none());
     }
 
     #[test]
@@ -188,11 +193,30 @@ mod tests {
         let original = FilterOptions {
             keep_size: "100MB".to_string(),
             keep_days: 30,
+            name_pattern: None,
         };
         let cloned = original.clone();
 
         assert_eq!(original.keep_size, cloned.keep_size);
         assert_eq!(original.keep_days, cloned.keep_days);
+        assert_eq!(original.name_pattern, cloned.name_pattern);
+    }
+
+    #[test]
+    fn test_filter_options_name_pattern() {
+        let with_glob = FilterOptions {
+            keep_size: "0".to_string(),
+            keep_days: 0,
+            name_pattern: Some("my-app*".to_string()),
+        };
+        assert_eq!(with_glob.name_pattern.as_deref(), Some("my-app*"));
+
+        let with_regex = FilterOptions {
+            keep_size: "0".to_string(),
+            keep_days: 0,
+            name_pattern: Some("regex:^client-.*".to_string()),
+        };
+        assert_eq!(with_regex.name_pattern.as_deref(), Some("regex:^client-.*"));
     }
 
     #[test]


### PR DESCRIPTION
```bash
# Only clean projects whose name matches a glob pattern
clean-dev-dirs --name "my-app*"

# Glob with single-character wildcard
clean-dev-dirs --name "app-?"

# Use a regular expression (prefix with regex:)
clean-dev-dirs --name "regex:^client-.*"

# Combine with other filters
clean-dev-dirs --name "regex:^client-" --keep-size 50MB --dry-run
```