### PR TITLE
[FEAT] use selected projects for cleanup count and display

### DIFF
--- a/src/filtering.rs
+++ b/src/filtering.rs
@@ -198,7 +198,7 @@ pub fn sort_projects(projects: &mut Vec<Project>, sort_opts: &SortOptions) {
             });
         }
         SortCriteria::Type => {
-            projects.sort_by(|a, b| type_order(&a.kind).cmp(&type_order(&b.kind)));
+            projects.sort_by_key(|a| type_order(&a.kind));
         }
     }
 
@@ -225,7 +225,7 @@ fn sort_by_age(projects: &mut Vec<Project>) {
         })
         .collect();
 
-    decorated.sort_by(|a, b| a.1.cmp(&b.1));
+    decorated.sort_by_key(|a| a.1);
 
     projects.extend(decorated.into_iter().map(|(p, _)| p));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,7 +123,9 @@ fn inner_main() -> Result<()> {
         projects.print_summary(total_size);
     }
 
-    let Some(keep_executables) = resolve_keep_executables(&projects, &execution_options)? else {
+    let Some((projects, keep_executables)) =
+        resolve_keep_executables(projects, &execution_options)?
+    else {
         return Ok(());
     };
 
@@ -131,7 +133,13 @@ fn inner_main() -> Result<()> {
         return print_dry_run(&projects, json_mode);
     }
 
-    if !confirm_cleanup(projects.len(), total_size, execution_options.yes, json_mode)? {
+    let confirm_size = projects.get_total_size();
+    if !confirm_cleanup(
+        projects.len(),
+        confirm_size,
+        execution_options.yes,
+        json_mode,
+    )? {
         return Ok(());
     }
 
@@ -362,12 +370,14 @@ fn print_empty_result(json_mode: bool, message: &str) -> Result<()> {
 
 /// Handle interactive project selection and the keep-executables prompt.
 ///
-/// Returns `Ok(Some(keep))` to continue with the resolved flag, or
-/// `Ok(None)` when the user selected zero projects (caller should exit).
+/// Returns `Ok(Some((projects, keep)))` where `projects` is the user-selected
+/// subset (interactive mode) or the full set (non-interactive), and `keep` is
+/// the resolved keep-executables flag. Returns `Ok(None)` when the user
+/// selected zero projects (caller should exit).
 fn resolve_keep_executables(
-    projects: &Projects,
+    projects: Projects,
     opts: &clean_dev_dirs::ExecutionOptions,
-) -> Result<Option<bool>> {
+) -> Result<Option<(Projects, bool)>> {
     let mut keep = opts.keep_executables;
 
     if opts.interactive {
@@ -382,9 +392,11 @@ fn resolve_keep_executables(
                 .with_default(false)
                 .prompt()?;
         }
+
+        return Ok(Some((Projects::from(selected), keep)));
     }
 
-    Ok(Some(keep))
+    Ok(Some((projects, keep)))
 }
 
 /// Ask the user to confirm before proceeding with deletion.

--- a/src/project/projects.rs
+++ b/src/project/projects.rs
@@ -7,7 +7,7 @@
 use anyhow::Result;
 use colored::Colorize;
 use humansize::{DECIMAL, format_size};
-use inquire::MultiSelect;
+use inquire::{MultiSelect, list_option::ListOption};
 use rayon::prelude::*;
 
 use crate::project::ProjectType;
@@ -183,6 +183,12 @@ impl Projects {
 
         let selections = MultiSelect::new("Select projects to clean:", items)
             .with_default(&defaults)
+            .with_formatter(&|opts: &[ListOption<&String>]| {
+                opts.iter()
+                    .map(|o| o.value.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            })
             .prompt()?;
 
         Ok(selections

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -479,8 +479,7 @@ impl Scanner {
     /// Return true if the given `Cargo.toml` declares a `[workspace]` section.
     fn is_cargo_workspace_root(cargo_toml: &Path) -> bool {
         fs::read_to_string(cargo_toml)
-            .map(|content| content.lines().any(|line| line.trim() == "[workspace]"))
-            .unwrap_or(false)
+            .is_ok_and(|content| content.lines().any(|line| line.trim() == "[workspace]"))
     }
 
     /// Return true if `path` is inside a Rust workspace (an ancestor directory


### PR DESCRIPTION
Closes #48 

- `resolve_keep_executables` previously returned `Option<bool>` and took `&Projects`, so the `Vec<Project>` returned by `interactive_selection` was dropped immediately after the empty-check. The full pre-selection list was then passed to `confirm_cleanup` and `run_cleanup`. Now the `resolve_keep_executables` function takes `Projects` by value and returns `Option<(Projects, bool)>`, threading the selected subset through to the confirmation and deletion.
- Confirmation size is recomputed from the returned (possibly filtered) projects, so "Clean N projects (X GB)?" reflects only what was selected. 
- Added `with_formatter` to the `MultiSelect` to render confirmed selections one path per line instead of a comma-separated blob. 
- Fixed three pedantic/complexity clippy lints (`sort_by` → `sort_by_key`, `map().unwrap_or(false)` → `is_ok_and`). 