### PR TITLE
[FEAT] Parallelize directory traversal with `jwalk`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clean-dev-dirs"
-version = "2.8.1"
+version = "2.8.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -189,6 +189,7 @@ dependencies = [
  "humansize",
  "indicatif",
  "inquire",
+ "jwalk",
  "rayon",
  "regex",
  "serde",
@@ -246,6 +247,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +283,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -564,6 +596,16 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
+dependencies = [
+ "crossbeam",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "Apache-2.0 OR MIT"
 name = "clean-dev-dirs"
 readme = "README.md"
 repository = "https://github.com/clean-dev-dirs/clean-dev-dirs"
-version = "2.8.1"
+version = "2.8.2"
 
 [lib]
 name = "clean_dev_dirs"
@@ -44,6 +44,7 @@ serde_json = "1.0.149"
 toml = "0.8"
 trash = "5.2.5"
 walkdir = "2.5.0"
+jwalk = "0.8.1"
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/PRs/parallel-walk-jwalk.md
+++ b/PRs/parallel-walk-jwalk.md
@@ -1,0 +1,40 @@
+## Parallelize directory traversal with `jwalk`
+
+### Summary
+
+The scanner walked the filesystem with `walkdir`, which is single-threaded; `rayon` only parallelized the per-project size calculation and detection. For a tool whose dominant cost is `stat()`-ing large numbers of inodes, the walk itself was the most credible performance lever.
+
+This PR replaces the detection walk with [`jwalk`](https://crates.io/crates/jwalk), which reads directories in parallel on the rayon pool, and prunes `node_modules` descent during the walk. Behaviour is unchanged: the same projects are detected, all 227 tests pass, and clippy (pedantic + nursery, `-D warnings`) is clean.
+
+### Changes
+
+**Parallel walk (`src/scanner.rs`)**
+
+- Swapped `walkdir::WalkDir` for `jwalk::WalkDir` in `Scanner::scan_directory`. The walk now runs across the rayon pool instead of on a single thread.
+- Added a `process_read_dir` callback that prunes `node_modules` directories (`read_children_path = None`). Nothing inside a `node_modules` tree is ever a project candidate (`should_scan_entry` already filtered it), so skipping descent is behaviour-preserving and avoids stat-ing the deepest, largest part of most JavaScript projects.
+- `--threads 1` now uses `Parallelism::Serial`. jwalk's default `RayonDefaultPool` can stall when the global rayon pool only has a single thread, so the serial path keeps single-threaded scans correct.
+- `should_scan_entry` and `detect_project` now take a `&Path` (+ an `is_dir` flag) instead of a `walkdir::DirEntry`, decoupling them from the walker implementation.
+
+**Docs**
+
+- Updated the acknowledgements in `README.md` (added jwalk; noted WalkDir is still used for size calculation).
+
+### Benchmarks
+
+Synthetic tree: ~72k inodes, 223 MB, 80 projects (40 Node with `node_modules`, 40 Rust with `target/`, plus plain trees). 12 alternating runs after warmup, release builds.
+
+| Scenario | baseline (walkdir) | jwalk | speedup (median) |
+|---|---|---|---|
+| Full tree | 563 ms | 375 ms | **1.50x** |
+| Plain trees, no `node_modules` (pure parallel walk) | 87 ms | 72 ms | 1.20x |
+| Rust + `target/` (not pruned) | 64 ms | 55 ms | 1.17x |
+| Node + `node_modules` (pruned) | 397 ms | 217 ms | **1.83x** |
+
+Attribution: the parallel walk alone contributes ~1.2x; the bulk of the gain on JS-heavy trees comes from pruning `node_modules` descent (1.83x). Real dev directories are typically dominated by `node_modules`/`target`, so the combined effect should be at least as pronounced.
+
+### Notes / follow-ups
+
+- `walkdir` remains a dependency: `src/utils/size.rs::calculate_dir_size` still uses it. That size phase is also stat-intensive (it walks `target`/`node_modules` to sum sizes); parallelizing it via jwalk is a plausible next step, but it already runs inside a rayon `par_iter` at the project level, so nested parallelism should be benchmarked before committing to it.
+- No public API or CLI change.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/README.md
+++ b/README.md
@@ -861,7 +861,8 @@ Built with excellent open-source libraries:
 - [Colored](https://crates.io/crates/colored) - Beautiful colored terminal output
 - [Indicatif](https://crates.io/crates/indicatif) - Progress bars and spinners
 - [Inquire](https://crates.io/crates/inquire) - Interactive prompts and selection
-- [WalkDir](https://crates.io/crates/walkdir) - Recursive directory iteration
+- [jwalk](https://crates.io/crates/jwalk) - Parallel recursive directory traversal
+- [WalkDir](https://crates.io/crates/walkdir) - Recursive directory iteration (used for directory size calculation)
 - [Humansize](https://crates.io/crates/humansize) - Human-readable file sizes
 - [Serde](https://crates.io/crates/serde) + [serde_json](https://crates.io/crates/serde_json) + [TOML](https://crates.io/crates/toml) - Serialization, JSON output, and configuration file parsing
 - [dirs](https://crates.io/crates/dirs) - Cross-platform config directory resolution

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -16,9 +16,9 @@ use std::{
 
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressStyle};
+use jwalk::{Parallelism, WalkDir};
 use rayon::prelude::*;
 use serde_json::{Value, from_str};
-use walkdir::{DirEntry, WalkDir};
 
 use crate::{
     config::{ProjectFilter, ScanOptions},
@@ -141,20 +141,44 @@ impl Scanner {
         let progress_clone = progress.clone();
         let count_clone = Arc::clone(&found_count);
 
-        // Find all potential project directories
-        let walker = self.scan_options.max_depth.map_or_else(
-            || WalkDir::new(root),
-            |depth| WalkDir::new(root).max_depth(depth),
+        // Walk the tree in parallel with jwalk (read_dir runs across the rayon
+        // pool) instead of walkdir's single-threaded walk. The walk is the
+        // dominant cost for this tool, which stat()s large numbers of inodes.
+        let mut walker = WalkDir::new(root).skip_hidden(false).process_read_dir(
+            |_depth, _path, _state, children| {
+                // Prune: never descend into node_modules. Nothing inside a
+                // node_modules tree is ever a project candidate (see
+                // `should_scan_entry`), so skipping descent is
+                // behaviour-preserving and avoids stat-ing the deepest, largest
+                // part of most JavaScript projects.
+                for child in children.iter_mut().flatten() {
+                    if child.file_type.is_dir()
+                        && child.file_name == *std::ffi::OsStr::new("node_modules")
+                    {
+                        child.read_children_path = None;
+                    }
+                }
+            },
         );
+
+        // jwalk's default RayonDefaultPool can stall when the global pool only
+        // has a single thread; honour `--threads 1` with a serial walk instead.
+        if self.scan_options.threads == 1 {
+            walker = walker.parallelism(Parallelism::Serial);
+        }
+        if let Some(depth) = self.scan_options.max_depth {
+            walker = walker.max_depth(depth);
+        }
 
         let potential_projects: Vec<_> = walker
             .into_iter()
             .filter_map(Result::ok)
-            .filter(|entry| self.should_scan_entry(entry))
+            .map(|entry| (entry.path(), entry.file_type().is_dir()))
+            .filter(|(path, _)| self.should_scan_entry(path))
             .collect::<Vec<_>>()
             .into_par_iter()
-            .filter_map(|entry| {
-                let result = self.detect_project(&entry, &errors);
+            .filter_map(|(path, is_dir)| {
+                let result = self.detect_project(&path, is_dir, &errors);
                 if result.is_some() {
                     let n = count_clone.fetch_add(1, Ordering::Relaxed) + 1;
                     progress_clone.set_message(format!("Scanning... {n} found"));
@@ -334,12 +358,11 @@ impl Scanner {
     /// - **Zig projects**: Presence of `build.zig` with `zig-cache/` or `zig-out/`
     fn detect_project(
         &self,
-        entry: &DirEntry,
+        path: &Path,
+        is_dir: bool,
         errors: &Arc<Mutex<Vec<String>>>,
     ) -> Option<Project> {
-        let path = entry.path();
-
-        if !entry.file_type().is_dir() {
+        if !is_dir {
             return None;
         }
 
@@ -672,9 +695,7 @@ impl Scanner {
     /// - Python coverage files
     /// - Node.js modules (already handled above but added for completeness)
     /// - .NET `obj/` directory
-    fn should_scan_entry(&self, entry: &DirEntry) -> bool {
-        let path = entry.path();
-
+    fn should_scan_entry(&self, path: &Path) -> bool {
         // Early return if path is in skip list
         if self.is_path_in_skip_list(path) {
             return false;


### PR DESCRIPTION
### Summary

The scanner walked the filesystem with `walkdir`, which is single-threaded; `rayon` only parallelized the per-project size calculation and detection. For a tool whose dominant cost is `stat()`-ing large numbers of inodes, the walk itself was the most credible performance lever.

This PR replaces the detection walk with [`jwalk`](https://crates.io/crates/jwalk), which reads directories in parallel on the rayon pool, and prunes `node_modules` descent during the walk. Behaviour is unchanged: the same projects are detected, all 227 tests pass, and clippy (pedantic + nursery, `-D warnings`) is clean.

### Changes

**Parallel walk (`src/scanner.rs`)**

- Swapped `walkdir::WalkDir` for `jwalk::WalkDir` in `Scanner::scan_directory`. The walk now runs across the rayon pool instead of on a single thread.
- Added a `process_read_dir` callback that prunes `node_modules` directories (`read_children_path = None`). Nothing inside a `node_modules` tree is ever a project candidate (`should_scan_entry` already filtered it), so skipping descent is behaviour-preserving and avoids stat-ing the deepest, largest part of most JavaScript projects.
- `--threads 1` now uses `Parallelism::Serial`. jwalk's default `RayonDefaultPool` can stall when the global rayon pool only has a single thread, so the serial path keeps single-threaded scans correct.
- `should_scan_entry` and `detect_project` now take a `&Path` (+ an `is_dir` flag) instead of a `walkdir::DirEntry`, decoupling them from the walker implementation.

**Docs**

- Updated the acknowledgements in `README.md` (added jwalk; noted WalkDir is still used for size calculation).

### Benchmarks

Synthetic tree: ~72k inodes, 223 MB, 80 projects (40 Node with `node_modules`, 40 Rust with `target/`, plus plain trees). 12 alternating runs after warmup, release builds.

| Scenario | baseline (walkdir) | jwalk | speedup (median) |
|---|---|---|---|
| Full tree | 563 ms | 375 ms | **1.50x** |
| Plain trees, no `node_modules` (pure parallel walk) | 87 ms | 72 ms | 1.20x |
| Rust + `target/` (not pruned) | 64 ms | 55 ms | 1.17x |
| Node + `node_modules` (pruned) | 397 ms | 217 ms | **1.83x** |

Attribution: the parallel walk alone contributes ~1.2x; the bulk of the gain on JS-heavy trees comes from pruning `node_modules` descent (1.83x). Real dev directories are typically dominated by `node_modules`/`target`, so the combined effect should be at least as pronounced.

### Notes / follow-ups

- `walkdir` remains a dependency: `src/utils/size.rs::calculate_dir_size` still uses it. That size phase is also stat-intensive (it walks `target`/`node_modules` to sum sizes); parallelizing it via jwalk is a plausible next step, but it already runs inside a rayon `par_iter` at the project level, so nested parallelism should be benchmarked before committing to it.
- No public API or CLI change.
